### PR TITLE
Configure Corne keymap for ZMK Studio

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -15,7 +15,7 @@
 &sk { quick-release; };
 
 / {
-    chosen { zmk,matrix_transform = &five_column_transform; };
+    chosen { zmk,physical-layout = &foostan_corne_5col_layout; };
 
     combos {
         compatible = "zmk,combos";


### PR DESCRIPTION
## Summary
- reference Corne's physical layout instead of matrix transform when ZMK Studio is enabled

## Testing
- `west update --fetch-opt=--filter=blob:none`
- `west zephyr-export`
- `west build -s zmk/app -d build-left -b nice_nano_v2 -S studio-rpc-usb-uart -- -DZMK_CONFIG=./config -DSHIELD="corne_left nice_view_adapter nice_view_battery"` *(fails: Could not find package configuration file provided by "Zephyr-sdk")*


------
https://chatgpt.com/codex/tasks/task_e_68a7a5255b7483218b50a70ac750748e