### PR TITLE
Add five-column layout transform to Corne keymap

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -15,7 +15,10 @@
 &sk { quick-release; };
 
 / {
-    chosen { zmk,physical-layout = &foostan_corne_5col_layout; };
+    chosen {
+        zmk,physical-layout = &foostan_corne_5col_layout;
+        zmk,layout-transform = &five_column_transform;
+    };
 
     combos {
         compatible = "zmk,combos";


### PR DESCRIPTION
## Summary
- reference five-column physical layout and transform in Corne keymap

## Testing
- `just build corne` *(fails: west: unknown command "build"; do you need to run this inside a workspace?)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aad5e48c832180e94b8d59b99bdb